### PR TITLE
Fix a strange bug(?) in prompt insertion

### DIFF
--- a/tempo-snippets.el
+++ b/tempo-snippets.el
@@ -379,7 +379,7 @@ tempo-interactive set to nil."
     (setq overlay (make-overlay beg (point)))
     (overlay-put overlay 'tempo-snippets-save-name
                  (cons tempo-snippets-instance-counter save-name))
-    (overlay-put overlay 'tempo-snippets-prompt text)
+    (overlay-put overlay 'tempo-snippets-prompt prompt)
     (overlay-put overlay 'face 'tempo-snippets-editable-face)
     (overlay-put overlay 'intangible t)
     (overlay-put overlay 'modification-hooks '(tempo-snippets-update))

--- a/tempo-snippets.el
+++ b/tempo-snippets.el
@@ -374,12 +374,8 @@ tempo-interactive set to nil."
   "Insert a snippet prompt at point."
   (tempo-insert-mark (point-marker))
   (let ((beg (point))
-        (text (replace-regexp-in-string "[[:space:]]" "_"
-                                        (if (string-match "\\(.+\\): " prompt)
-                                            (match-string 1 prompt)
-                                          prompt)))
         overlay)
-    (insert text)
+    (insert prompt)
     (setq overlay (make-overlay beg (point)))
     (overlay-put overlay 'tempo-snippets-save-name
                  (cons tempo-snippets-instance-counter save-name))


### PR DESCRIPTION
Prompts that contained a colon followed by a space would lose all characters after the last such pair.  There also seems to be no good reason to replace spaces with underscores.
